### PR TITLE
Exposing these to build sessions in the back end

### DIFF
--- a/mongo/tranquil_client.go
+++ b/mongo/tranquil_client.go
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2020, Tranquil Data, Inc. All rights reserved.
+ */
+
+package mongo
+
+import (
+	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
+)
+
+func (c *Client) GetSessionPool() *session.Pool {
+	return c.sessionPool
+}
+
+func (c *Client) GetID() uuid.UUID {
+	return c.id
+}


### PR DESCRIPTION
The driver keeps sessions pretty contained, but we'll need to build new ones in both the front and back end and outside of a single client instance.

re: https://tranquildata.atlassian.net/browse/TD-74